### PR TITLE
Fix dead link on https://psdev.de/LicensesDialog/

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
 <h2>
 <a id="usage" class="anchor" href="#usage" aria-hidden="true"><span class="octicon octicon-link"></span></a>Usage</h2>
 
-<p>You can take a look at the <a href="sample/src/main/java/de/psdev/licensesdialog/sample/SampleActivity.java">SampleActivity.java</a> 
+<p>You can take a look at the <a href="https://github.com/PSDev/LicensesDialog/blob/master/sample/src/main/java/de/psdev/licensesdialog/sample/SampleActivity.java">SampleActivity.java</a> 
 from the sample module for examples on how to create the dialogs. </p>
 
 <h2>


### PR DESCRIPTION
https://psdev.de/LicensesDialog/ contains dead link.