### PR TITLE
Fix all tags after user-defined tag are skipped

### DIFF
--- a/library/src/main/java/de/psdev/licensesdialog/NoticesXmlParser.java
+++ b/library/src/main/java/de/psdev/licensesdialog/NoticesXmlParser.java
@@ -122,6 +122,21 @@ public final class NoticesXmlParser {
         return result;
     }
 
-    private static void skip(final XmlPullParser parser) {
+    private static void skip(final XmlPullParser parser) throws XmlPullParserException, IOException {
+        // http://stackoverflow.com/a/23365815/1474113
+        if (parser.getEventType() != XmlPullParser.START_TAG) {
+            throw new IllegalStateException("Tried to not-start tag.");
+        }
+        int depth = 1;
+        while (depth != 0) {
+            switch (parser.next()) {
+                case XmlPullParser.END_TAG:
+                    depth--;
+                    break;
+                case XmlPullParser.START_TAG:
+                    depth++;
+                    break;
+            }
+        }
     }
 }


### PR DESCRIPTION
Currently `NoticesXmlParser#skip(...)` does nothing and exits while loop at [here](https://github.com/ypresto/LicensesDialog/blob/18f5d830d582d88ac991cbe05b874c75bc9610a8/library/src/main/java/de/psdev/licensesdialog/NoticesXmlParser.java#L50).

I want to place custom tag contains gradle artifact specifier, to automate out-of-sync detection between build.gradle and notices.xml

``` xml
        <artifacts>
            <artifact>commons-io:commons-io:2.4</artifact>
        </artifacts>
```
