### PR TITLE
Change AlertDialog Version

### DIFF
--- a/library/src/main/java/de/psdev/licensesdialog/LicensesDialog.java
+++ b/library/src/main/java/de/psdev/licensesdialog/LicensesDialog.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import android.app.AlertDialog;
+import android.support.v7.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;


### PR DESCRIPTION
android.app.AlertDialog is Holo UI AlertDialog.

I think We don't have to use Holo UI AlertDialog anymore, So I changed to v7 Material Design AlertDialog.

So many people will like it :D