### PR TITLE
Removed unused throws declaration

### DIFF
--- a/library/src/main/java/de/psdev/licensesdialog/LicensesDialogFragment.java
+++ b/library/src/main/java/de/psdev/licensesdialog/LicensesDialogFragment.java
@@ -272,7 +272,7 @@ public class LicensesDialogFragment extends DialogFragment {
             return this;
         }
 
-        public Builder setNotices(@RawRes final int rawNoticesResourceId) throws Exception {
+        public Builder setNotices(@RawRes final int rawNoticesResourceId) {
             mRawNoticesResourceId = rawNoticesResourceId;
             return this;
         }


### PR DESCRIPTION
setNotices() doesn't throw anything, so it doesn't need to declare a thrown exception.