### PR TITLE
Make the LicensesDialogFragment's licenses text styleable

### DIFF
--- a/library/src/main/java/de/psdev/licensesdialog/LicensesDialogFragment.java
+++ b/library/src/main/java/de/psdev/licensesdialog/LicensesDialogFragment.java
@@ -26,8 +26,10 @@ import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.RawRes;
+import android.support.annotation.StringRes;
 import android.support.annotation.StyleRes;
 import android.support.v4.app.DialogFragment;
+
 import de.psdev.licensesdialog.model.Notice;
 import de.psdev.licensesdialog.model.Notices;
 
@@ -40,6 +42,7 @@ public class LicensesDialogFragment extends DialogFragment {
     private static final String ARGUMENT_THEME_XML_ID = "ARGUMENT_THEME_XML_ID";
     private static final String ARGUMENT_DIVIDER_COLOR = "ARGUMENT_DIVIDER_COLOR";
     private static final String ARGUMENT_USE_APPCOMPAT = "ARGUMENT_USE_APPCOMPAT";
+    private static final String ARGUMENT_NOTICE_STYLE = "ARGUMENT_NOTICE_STYLE";
     private static final String STATE_TITLE_TEXT = "title_text";
     private static final String STATE_LICENSES_TEXT = "licenses_text";
     private static final String STATE_CLOSE_TEXT = "close_text";
@@ -62,6 +65,7 @@ public class LicensesDialogFragment extends DialogFragment {
     private static LicensesDialogFragment newInstance(final Notices notices,
                                                       final boolean showFullLicenseText,
                                                       final boolean includeOwnLicense,
+                                                      final String noticeStyle,
                                                       final int themeResourceId,
                                                       final int dividerColor,
                                                       final boolean useAppCompat) {
@@ -70,6 +74,7 @@ public class LicensesDialogFragment extends DialogFragment {
         args.putParcelable(ARGUMENT_NOTICES, notices);
         args.putBoolean(ARGUMENT_FULL_LICENSE_TEXT, showFullLicenseText);
         args.putBoolean(ARGUMENT_INCLUDE_OWN_LICENSE, includeOwnLicense);
+        args.putString(ARGUMENT_NOTICE_STYLE, noticeStyle);
         args.putInt(ARGUMENT_THEME_XML_ID, themeResourceId);
         args.putInt(ARGUMENT_DIVIDER_COLOR, dividerColor);
         args.putBoolean(ARGUMENT_USE_APPCOMPAT, useAppCompat);
@@ -80,6 +85,7 @@ public class LicensesDialogFragment extends DialogFragment {
     private static LicensesDialogFragment newInstance(final int rawNoticesResourceId,
                                                       final boolean showFullLicenseText,
                                                       final boolean includeOwnLicense,
+                                                      final String noticeStyle,
                                                       final int themeResourceId,
                                                       final int dividerColor,
                                                       final boolean useAppCompat) {
@@ -88,6 +94,7 @@ public class LicensesDialogFragment extends DialogFragment {
         args.putInt(ARGUMENT_NOTICES_XML_ID, rawNoticesResourceId);
         args.putBoolean(ARGUMENT_FULL_LICENSE_TEXT, showFullLicenseText);
         args.putBoolean(ARGUMENT_INCLUDE_OWN_LICENSE, includeOwnLicense);
+        args.putString(ARGUMENT_NOTICE_STYLE, noticeStyle);
         args.putInt(ARGUMENT_THEME_XML_ID, themeResourceId);
         args.putInt(ARGUMENT_DIVIDER_COLOR, dividerColor);
         args.putBoolean(ARGUMENT_USE_APPCOMPAT, useAppCompat);
@@ -153,7 +160,11 @@ public class LicensesDialogFragment extends DialogFragment {
                             mDividerColor = arguments.getInt(ARGUMENT_DIVIDER_COLOR);
                         }
                     }
-                    mLicensesText = NoticesHtmlBuilder.create(getActivity()).setNotices(notices).setShowFullLicenseText(showFullLicenseText).build();
+                    String noticeStyle = arguments.getString(ARGUMENT_NOTICE_STYLE);
+                    if (noticeStyle == null) {
+                        noticeStyle = resources.getString(R.string.notices_default_style);
+                    }
+                    mLicensesText = NoticesHtmlBuilder.create(getActivity()).setNotices(notices).setShowFullLicenseText(showFullLicenseText).setStyle(noticeStyle).build();
                 } else {
                     throw new IllegalStateException("Missing arguments");
                 }
@@ -239,6 +250,7 @@ public class LicensesDialogFragment extends DialogFragment {
         private Integer mRawNoticesResourceId;
         private boolean mShowFullLicenseText;
         private boolean mIncludeOwnLicense;
+        private String mNoticesStyle;
         private int mThemeResourceId;
         private int mDividerColor;
         private boolean mUseAppCompat;
@@ -252,6 +264,7 @@ public class LicensesDialogFragment extends DialogFragment {
             // Set default values
             mShowFullLicenseText = false;
             mIncludeOwnLicense = true;
+            mNoticesStyle = context.getString(R.string.notices_default_style);
             mThemeResourceId = 0;
             mDividerColor = 0;
             mUseAppCompat = false;
@@ -287,6 +300,16 @@ public class LicensesDialogFragment extends DialogFragment {
             return this;
         }
 
+        public Builder setNoticesCssStyle(@StringRes final int cssStyleTextId) {
+            mNoticesStyle = mContext.getString(cssStyleTextId);
+            return this;
+        }
+
+        public Builder setNoticesCssStyle(final String cssStyleText) {
+            mNoticesStyle = cssStyleText;
+            return this;
+        }
+
         public Builder setThemeResourceId(@StyleRes final int themeResourceId) {
             mThemeResourceId = themeResourceId;
             return this;
@@ -309,9 +332,9 @@ public class LicensesDialogFragment extends DialogFragment {
 
         public LicensesDialogFragment build() {
             if (mNotices != null) {
-                return newInstance(mNotices, mShowFullLicenseText, mIncludeOwnLicense, mThemeResourceId, mDividerColor, mUseAppCompat);
+                return newInstance(mNotices, mShowFullLicenseText, mIncludeOwnLicense, mNoticesStyle, mThemeResourceId, mDividerColor, mUseAppCompat);
             } else if (mRawNoticesResourceId != null) {
-                return newInstance(mRawNoticesResourceId, mShowFullLicenseText, mIncludeOwnLicense, mThemeResourceId, mDividerColor, mUseAppCompat);
+                return newInstance(mRawNoticesResourceId, mShowFullLicenseText, mIncludeOwnLicense, mNoticesStyle, mThemeResourceId, mDividerColor, mUseAppCompat);
             } else {
                 throw new IllegalStateException("Required parameter not set. You need to call setNotices.");
             }

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <!-- Dependency Versions -->
         <junit.version>4.12</junit.version>
         <robolectric.version>3.0</robolectric.version>
-        <android.version>4.1.1.4</android.version>
+        <android.version>7.1.1_r3</android.version>
         <android-support.version>25.2.0</android-support.version>
         <jsr305.version>3.0.1</jsr305.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,24 +70,31 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.6</java.version>
-        <android.sdk.platform>23</android.sdk.platform>
+        <android.sdk.platform>25</android.sdk.platform>
 
         <!-- Dependency Versions -->
         <junit.version>4.12</junit.version>
         <robolectric.version>3.0</robolectric.version>
-        <android.version>6.0_r3</android.version>
-        <android-support.version>23.3.0</android-support.version>
+        <android.version>4.1.1.4</android.version>
+        <android-support.version>25.2.0</android-support.version>
         <jsr305.version>3.0.1</jsr305.version>
 
         <!-- Plugin Versions -->
-        <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
-        <android-maven-plugin.version>4.4.1</android-maven-plugin.version>
+        <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
+        <android-maven-plugin.version>4.4.3</android-maven-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-        <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
-        <maven-source-plugin.version>3.0.0</maven-source-plugin.version>
-        <jacoco-maven-plugin.version>0.7.6.201602180812</jacoco-maven-plugin.version>
+        <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>android-support</id>
+            <url>file://${env.ANDROID_HOME}/extras/android/m2repository</url>
+        </repository>
+    </repositories>
 
     <dependencyManagement>
         <dependencies>

--- a/sample/res/layout/activity_sample.xml
+++ b/sample/res/layout/activity_sample.xml
@@ -15,78 +15,97 @@
   ~    limitations under the License.
   -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
-    <Button
+    <LinearLayout 
+        android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/single"
-        android:onClick="onSingleClick"
-        android:layout_weight="1" />
+        android:layout_height="match_parent">
 
-    <Button
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/multiple"
-        android:onClick="onMultipleClick"
-        android:layout_weight="1" />
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/single"
+            android:onClick="onSingleClick"
+            android:layout_weight="1" />
 
-    <Button
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/multiple_include_own"
-        android:onClick="onMultipleIncludeOwnClick"
-        android:layout_weight="1" />
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/multiple"
+            android:onClick="onMultipleClick"
+            android:layout_weight="1" />
 
-    <Button
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/multiple_programmatic"
-        android:onClick="onMultipleProgrammaticClick"
-        android:layout_weight="1" />
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/multiple_include_own"
+            android:onClick="onMultipleIncludeOwnClick"
+            android:layout_weight="1" />
 
-    <Button
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/single_fragment"
-        android:onClick="onSingleFragmentClick"
-        android:layout_weight="1" />
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/multiple_programmatic"
+            android:onClick="onMultipleProgrammaticClick"
+            android:layout_weight="1" />
 
-    <Button
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/multiple_fragment"
-        android:onClick="onMultipleFragmentClick"
-        android:layout_weight="1" />
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/single_fragment"
+            android:onClick="onSingleFragmentClick"
+            android:layout_weight="1" />
 
-    <Button
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/multiple_include_own_fragment"
-        android:onClick="onMultipleIncludeOwnFragmentClick"
-        android:layout_weight="1" />
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/multiple_fragment"
+            android:onClick="onMultipleFragmentClick"
+            android:layout_weight="1" />
 
-    <Button
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/multiple_programmatic_fragment"
-        android:onClick="onMultipleProgrammaticFragmentClick"
-        android:layout_weight="1" />
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/multiple_include_own_fragment"
+            android:onClick="onMultipleIncludeOwnFragmentClick"
+            android:layout_weight="1" />
 
-    <Button
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/custom_theme"
-        android:onClick="onCustomThemeClick"
-        android:layout_weight="1" />
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/multiple_programmatic_fragment"
+            android:onClick="onMultipleProgrammaticFragmentClick"
+            android:layout_weight="1" />
 
-    <Button
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/custom_theme_fragment"
-        android:onClick="onCustomThemeFragmentClick"
-        android:layout_weight="1" />
-</LinearLayout>
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/custom_theme"
+            android:onClick="onCustomThemeClick"
+            android:layout_weight="1" />
+
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/custom_theme_fragment"
+            android:onClick="onCustomThemeFragmentClick"
+            android:layout_weight="1" />
+
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/custom_css_style"
+            android:onClick="onCustomCssStyleClick"
+            android:layout_weight="1" />
+
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/custom_css_style_fragment"
+            android:onClick="onCustomCssStyleFragmentClick"
+            android:layout_weight="1" />
+    </LinearLayout>
+</ScrollView>

--- a/sample/res/layout/activity_sample.xml
+++ b/sample/res/layout/activity_sample.xml
@@ -22,7 +22,7 @@
     <LinearLayout 
         android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content">
 
         <Button
             android:layout_width="match_parent"

--- a/sample/res/values/base_html.xml
+++ b/sample/res/values/base_html.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2017 Chaos Leong
+  ~ Copyright 2013 Philip Schiffer
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<resources>
+    <string name="coustom_notices_default_style" translatable="false">
+        p.license {
+        background:grey;
+        }
+        body {
+        font-family: sans-serif;
+        overflow-wrap: break-word;
+        background:#616161;
+        }
+        pre {
+        background-color: #eeeeee;
+        padding: 1em;
+        white-space: pre-wrap;
+        }
+    </string>
+    <string name="coustom_notices_format_style" translatable="false">
+        p.license {
+        %1$s
+        }
+        body {
+        font-family: sans-serif;
+        overflow-wrap: break-word;
+        %2$s
+        }
+        pre {
+        %3$s
+        padding: 1em;
+        white-space: pre-wrap;
+        }
+        li {
+        %4$s
+        }
+        li a {
+        %5$s
+        }
+    </string>
+</resources>

--- a/sample/res/values/strings.xml
+++ b/sample/res/values/strings.xml
@@ -28,4 +28,6 @@
     <string name="custom_theme_fragment">Custom theme (Fragment)</string>
     <string name="custom_css_style">Custom CSS Style</string>
     <string name="custom_css_style_fragment">Custom CSS Style (Fragment)</string>
+
+    <string name="rgba_background_format">background-color:rgba(%1$d,%2$d,%3$d,%4$1f);</string>
 </resources>

--- a/sample/res/values/strings.xml
+++ b/sample/res/values/strings.xml
@@ -26,4 +26,6 @@
     <string name="multiple_programmatic_fragment">Multiple programmaticly (Fragment)</string>
     <string name="custom_theme">Custom theme</string>
     <string name="custom_theme_fragment">Custom theme (Fragment)</string>
+    <string name="custom_css_style">Custom CSS Style</string>
+    <string name="custom_css_style_fragment">Custom CSS Style (Fragment)</string>
 </resources>

--- a/sample/src/main/java/de/psdev/licensesdialog/sample/AppCompatSampleActivity.java
+++ b/sample/src/main/java/de/psdev/licensesdialog/sample/AppCompatSampleActivity.java
@@ -169,6 +169,10 @@ public class AppCompatSampleActivity extends AppCompatActivity {
     }
 
     private String getRGBAString(@ColorInt int color) {
-        return "background-color: rgba(" + Color.red(color) + "," + Color.green(color) + "," + Color.blue(color) + "," + ((float) Color.alpha(color) / 255) + ");";
+        int red = Color.red(color);
+        int green = Color.green(color);
+        int blue = Color.blue(color);
+        float alpha = ((float) Color.alpha(color) / 255);
+        return String.format(getString(R.string.rgba_background_format), red, green, blue, alpha);
     }
 }

--- a/sample/src/main/java/de/psdev/licensesdialog/sample/AppCompatSampleActivity.java
+++ b/sample/src/main/java/de/psdev/licensesdialog/sample/AppCompatSampleActivity.java
@@ -1,6 +1,8 @@
 package de.psdev.licensesdialog.sample;
 
+import android.graphics.Color;
 import android.os.Bundle;
+import android.support.annotation.ColorInt;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import de.psdev.licensesdialog.LicensesDialog;
@@ -139,4 +141,34 @@ public class AppCompatSampleActivity extends AppCompatActivity {
         fragment.show(getSupportFragmentManager(), null);
     }
 
+    public void onCustomCssStyleClick(final View view) {
+        new LicensesDialog.Builder(this)
+            .setNotices(R.raw.notices)
+            .setNoticesCssStyle(R.string.coustom_notices_default_style)
+            .build()
+            .showAppCompat();
+    }
+
+    public void onCustomCssStyleFragmentClick(final View view) throws Exception {
+        String formatString = getString(R.string.coustom_notices_format_style);
+        String pBg = getRGBAString(Color.parseColor("#9E9E9E"));
+        String bodyBg = getRGBAString(Color.parseColor("#424242"));
+        String preBg = getRGBAString(Color.parseColor("#BDBDBD"));
+        String liColor = "color: #ffffff";
+        String linkColor = "color: #1976D2";
+
+        String style = String.format(formatString, pBg, bodyBg, preBg, liColor, linkColor);
+
+        final LicensesDialogFragment fragment = new LicensesDialogFragment.Builder(this)
+            .setNotices(R.raw.notices)
+            .setNoticesCssStyle(style)
+            .setUseAppCompat(true)
+            .build();
+
+        fragment.show(getSupportFragmentManager(), null);
+    }
+
+    private String getRGBAString(@ColorInt int color) {
+        return "background-color: rgba(" + Color.red(color) + "," + Color.green(color) + "," + Color.blue(color) + "," + ((float) Color.alpha(color) / 255) + ");";
+    }
 }

--- a/sample/src/main/java/de/psdev/licensesdialog/sample/SampleActivity.java
+++ b/sample/src/main/java/de/psdev/licensesdialog/sample/SampleActivity.java
@@ -16,7 +16,9 @@
 
 package de.psdev.licensesdialog.sample;
 
+import android.graphics.Color;
 import android.os.Bundle;
+import android.support.annotation.ColorInt;
 import android.support.v4.app.FragmentActivity;
 import android.view.View;
 import de.psdev.licensesdialog.LicensesDialog;
@@ -148,5 +150,35 @@ public class SampleActivity extends FragmentActivity {
             .build();
 
         fragment.show(getSupportFragmentManager(), null);
+    }
+
+    public void onCustomCssStyleClick(final View view) {
+        new LicensesDialog.Builder(this)
+            .setNotices(R.raw.notices)
+            .setNoticesCssStyle(R.string.coustom_notices_default_style)
+            .build()
+            .show();
+    }
+
+    public void onCustomCssStyleFragmentClick(final View view) throws Exception {
+        String formatString = getString(R.string.coustom_notices_format_style);
+        String pBg = getRGBAString(Color.parseColor("#9E9E9E"));
+        String bodyBg = getRGBAString(Color.parseColor("#424242"));
+        String preBg = getRGBAString(Color.parseColor("#BDBDBD"));
+        String liColor = "color: #ffffff";
+        String linkColor = "color: #1976D2";
+
+        String style = String.format(formatString, pBg, bodyBg, preBg, liColor, linkColor);
+
+        final LicensesDialogFragment fragment = new LicensesDialogFragment.Builder(this)
+            .setNotices(R.raw.notices)
+            .setNoticesCssStyle(style)
+            .build();
+
+        fragment.show(getSupportFragmentManager(), null);
+    }
+
+    private String getRGBAString(@ColorInt int color) {
+        return "background-color: rgba(" + Color.red(color) + "," + Color.green(color) + "," + Color.blue(color) + "," + ((float) Color.alpha(color) / 255) + ");";
     }
 }

--- a/sample/src/main/java/de/psdev/licensesdialog/sample/SampleActivity.java
+++ b/sample/src/main/java/de/psdev/licensesdialog/sample/SampleActivity.java
@@ -179,6 +179,10 @@ public class SampleActivity extends FragmentActivity {
     }
 
     private String getRGBAString(@ColorInt int color) {
-        return "background-color: rgba(" + Color.red(color) + "," + Color.green(color) + "," + Color.blue(color) + "," + ((float) Color.alpha(color) / 255) + ");";
+        int red = Color.red(color);
+        int green = Color.green(color);
+        int blue = Color.blue(color);
+        float alpha = ((float) Color.alpha(color) / 255);
+        return String.format(getString(R.string.rgba_background_format), red, green, blue, alpha);
     }
 }


### PR DESCRIPTION
Because the default css style is too bright in __night mode__, so I make the __LicensesDialogFragment__'s licenses text can be styled.

* Update dependencies
* Make LicensesDialogFragment's license text styleable
* Add samples for coustom css style