### PR TITLE
Applied Dark Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Thank you to all the contributors of this project, namely:
 - [Vladyslav Pohrebniakov](https://github.com/PSDev/LicensesDialog/commits?author=personaljesusua)
 - [Chris Pick](https://github.com/PSDev/LicensesDialog/commits?author=chrispix99)
 - [Yuya Tanaka](https://github.com/PSDev/LicensesDialog/commits?author=ypresto)
+- [Minjae Seon](https://github.com/PSDev/LicensesDialog/commits?author=Aftermoon-dev)
 
 License
 -------

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,15 @@
 buildscript {
     ext {
         // Plugin versions
-        androidGradlePluginVersion = "3.4.1"
+        androidGradlePluginVersion = '4.1.1'
         gradleVersionsPluginVersion = "0.21.0"
         sonarqubeGradlePluginVersion = "2.7.1"
         // Dependency versions
-        appcompatVersion = "1.0.2"
-        androidXTestVersion = "1.2.0"
-        junitVersion = "4.12"
+        appcompatVersion = "1.2.0"
+        androidXTestVersion = "1.3.0"
+        junitVersion = "4.13.1"
         robolectricVersion = "4.3"
+        androidXWebKitVersion = "1.4.0"
     }
     repositories {
         google()

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,6 @@ org.gradle.jvmargs=-Xmx8192m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-android.enableUnitTestBinaryResources=true
 
 # Project info
 projectName=LicensesDialog
@@ -35,3 +34,7 @@ projectIssueManagementSystem=GitHub Issues
 projectIssueManagementUrl=https://github.com/PSDev/LicensesDialog/issues
 projectCiManagementSystem=Jenkins
 projectCiManagementUrl=https://ci.psdev.de/job/PSDevLicensesDialog
+
+
+# Android
+android.useAndroidX=true

--- a/licensesdialog/build.gradle
+++ b/licensesdialog/build.gradle
@@ -6,7 +6,7 @@ project.description = "LicensesDialog (Library)"
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "29.0.3"
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 14

--- a/licensesdialog/build.gradle
+++ b/licensesdialog/build.gradle
@@ -5,12 +5,12 @@ apply from: rootProject.file('gradle/jacoco.gradle')
 project.description = "LicensesDialog (Library)"
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 30
+    buildToolsVersion "29.0.3"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 30
 
         versionName project.version
         versionCode buildVersionCode()
@@ -49,7 +49,7 @@ dependencies {
 
     // Android
     implementation "androidx.appcompat:appcompat:$appcompatVersion"
-
+    implementation "androidx.webkit:webkit:$androidXWebKitVersion"
 }
 
 sonarqube {

--- a/licensesdialog/src/main/java/de/psdev/licensesdialog/LicensesDialog.java
+++ b/licensesdialog/src/main/java/de/psdev/licensesdialog/LicensesDialog.java
@@ -27,6 +27,7 @@ import android.os.Message;
 import android.view.ContextThemeWrapper;
 import android.view.View;
 import android.webkit.WebChromeClient;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
@@ -121,15 +122,16 @@ public class LicensesDialog {
 
     private static WebView createWebView(final Context context, final boolean mEnableDarkMode) {
         final WebView webView = new WebView(context);
-        webView.getSettings().setSupportMultipleWindows(true);
+        final WebSettings webSettings = webView.getSettings();
+        webSettings.setSupportMultipleWindows(true);
 
-        if(mEnableDarkMode) {
+        if (mEnableDarkMode) {
             if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
                 final int nightFlag = context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
                 if (nightFlag == Configuration.UI_MODE_NIGHT_YES) {
-                    WebSettingsCompat.setForceDark(webView.getSettings(), WebSettingsCompat.FORCE_DARK_ON);
+                    WebSettingsCompat.setForceDark(webSettings, WebSettingsCompat.FORCE_DARK_ON);
                 } else {
-                    WebSettingsCompat.setForceDark(webView.getSettings(), WebSettingsCompat.FORCE_DARK_OFF);
+                    WebSettingsCompat.setForceDark(webSettings, WebSettingsCompat.FORCE_DARK_OFF);
                 }
             }
         }

--- a/licensesdialog/src/main/java/de/psdev/licensesdialog/LicensesDialog.java
+++ b/licensesdialog/src/main/java/de/psdev/licensesdialog/LicensesDialog.java
@@ -24,7 +24,6 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Message;
-import android.util.Log;
 import android.view.ContextThemeWrapper;
 import android.view.View;
 import android.webkit.WebChromeClient;

--- a/sample/src/main/java/de/psdev/licensesdialog/sample/MainActivity.java
+++ b/sample/src/main/java/de/psdev/licensesdialog/sample/MainActivity.java
@@ -179,6 +179,19 @@ public class MainActivity extends AppCompatActivity {
         fragment.show(getSupportFragmentManager(), null);
     }
 
+    public void onSingleDisableDarkModeClick(final View view) {
+        final String name = "LicensesDialog";
+        final String url = "http://psdev.de";
+        final String copyright = "Copyright 2013 Philip Schiffer <admin@psdev.de>";
+        final License license = new ApacheSoftwareLicense20();
+        final Notice notice = new Notice(name, url, copyright, license);
+        new LicensesDialog.Builder(this)
+                .setNotices(notice)
+                .setEnableDarkMode(false)
+                .build()
+                .show();
+    }
+
     private String getRGBAString(@ColorInt int color) {
         int red = Color.red(color);
         int green = Color.green(color);

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -34,6 +34,13 @@
         <Button
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:text="@string/single_disable_darkmode"
+            android:onClick="onSingleDisableDarkModeClick"
+            android:layout_weight="1" />
+
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:text="@string/multiple"
             android:onClick="onMultipleClick"
             android:layout_weight="1" />
@@ -106,13 +113,6 @@
             android:layout_height="wrap_content"
             android:text="@string/custom_css_style_fragment"
             android:onClick="onCustomCssStyleFragmentClick"
-            android:layout_weight="1" />
-
-        <Button
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/single_disable_darkmode"
-            android:onClick="onSingleDisableDarkModeClick"
             android:layout_weight="1" />
     </LinearLayout>
 </ScrollView>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -107,5 +107,12 @@
             android:text="@string/custom_css_style_fragment"
             android:onClick="onCustomCssStyleFragmentClick"
             android:layout_weight="1" />
+
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/single_disable_darkmode"
+            android:onClick="onSingleDisableDarkModeClick"
+            android:layout_weight="1" />
     </LinearLayout>
 </ScrollView>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="custom_theme_fragment" translatable="false">Custom theme (Fragment)</string>
     <string name="custom_css_style" translatable="false">Custom CSS Style</string>
     <string name="custom_css_style_fragment" translatable="false">Custom CSS Style (Fragment)</string>
+    <string name="single_disable_darkmode" translatable="false">Single (Disable Dark Mode)</string>
 
     <string name="rgba_background_format" translatable="false">background-color:rgba(%1$d,%2$d,%3$d,%4$1f);</string>
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
 
 <resources>
     <string name="single" translatable="false">Single</string>
+    <string name="single_disable_darkmode" translatable="false">Single (Disabled Dark Mode)</string>
     <string name="multiple" translatable="false">Multiple</string>
     <string name="multiple_include_own" translatable="false">Multiple with own License</string>
     <string name="multiple_programmatic" translatable="false">Multiple programmatically</string>
@@ -27,7 +28,6 @@
     <string name="custom_theme_fragment" translatable="false">Custom theme (Fragment)</string>
     <string name="custom_css_style" translatable="false">Custom CSS Style</string>
     <string name="custom_css_style_fragment" translatable="false">Custom CSS Style (Fragment)</string>
-    <string name="single_disable_darkmode" translatable="false">Single (Disable Dark Mode)</string>
 
     <string name="rgba_background_format" translatable="false">background-color:rgba(%1$d,%2$d,%3$d,%4$1f);</string>
 </resources>


### PR DESCRIPTION
In Android 10 (API Level 29) and higher, User can use Dark Mode. (https://developer.android.com/guide/topics/ui/look-and-feel/darktheme)

However, as I was using the library, I found that the contents of the LicensesDialog were not supported even if the app supported dark mode, and that it needed modification to be applied to WebView, the way that the dialog displays its content.

I have modified to support dark mode, basically following app or device's dark mode settings. 

![Dark Mode Example](https://user-images.githubusercontent.com/3215313/103835312-4028db00-50c9-11eb-8f3f-a8acfc400b5d.png)

However, we can disable the feature via setEnableDarkMode(false) if do not wish to. 
```java
    public void onSingleDisableDarkModeClick(final View view) {
        final String name = "LicensesDialog";
        final String url = "http://psdev.de";
        final String copyright = "Copyright 2013 Philip Schiffer <admin@psdev.de>";
        final License license = new ApacheSoftwareLicense20();
        final Notice notice = new Notice(name, url, copyright, license);
        new LicensesDialog.Builder(this)
                .setNotices(notice)
                .setEnableDarkMode(false)
                .build()
                .show();
    }
```