### PR TITLE
Support dark mode in sample app

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="LicensesDialog Sample"
-        android:theme="@style/Theme.AppCompat.Light.DarkActionBar"
+        android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar"
         tools:ignore="GoogleAppIndexingWarning">
         <activity android:name="de.psdev.licensesdialog.sample.MainActivity">
             <intent-filter>


### PR DESCRIPTION
Currently, the sample app has a light style by default by using Theme.AppCompat.DayNight.DarkActionBar, instead, we can provide full support of dark mode in the sample application. 

It also shows how others can have dark mode support in their dialog's top and bottom bar(title and button).